### PR TITLE
FIX go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ go install github.com/negbie/hammerHEP
 ```
 
 
-### Usage of hammerhep:
+### Usage of hammerHEP:
 
 ```bash
   -address string
@@ -27,5 +27,5 @@ go install github.com/negbie/hammerHEP
      
 ################################################################
 
-hammerhep -rate 100
+hammerHEP -rate 100
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ go install github.com/negbie/hammerHEP
 ```
 
 
-### Usage of ./hammerhep:
+### Usage of hammerhep:
 
 ```bash
   -address string
@@ -27,5 +27,5 @@ go install github.com/negbie/hammerHEP
      
 ################################################################
 
-./hammerhep -rate 100
+hammerhep -rate 100
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/negbie/hammerhep
+module github.com/negbie/hammerHEP
 
 go 1.13
 


### PR DESCRIPTION
When I run `go install github.com/negbie/hammerHEP` I have this error
```
go: github.com/negbie/hammerHEP: github.com/negbie/hammerHEP@v0.0.0-20200308183716-0721da93db7b: parsing go.mod:
	module declares its path as: github.com/negbie/hammerhep
        but was required as: github.com/negbie/hammerHEP
```
This simple PR fix that

Plus, when installed, we don't run `./hammerHEP` but `hammerHEP`

Thanks :)